### PR TITLE
Add macOS (`x86_64` and `arm64`) builds

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -30,7 +30,7 @@ jobs:
     steps:
       - name: Repo Check
         run: |
-          if [[ "$GITHUB_REPOSITORY" != "EIRTeam/FFmpeg-Builds" ]]; then
+          if [[ "$GITHUB_REPOSITORY" != "retrohub-org/FFmpeg-Builds" ]]; then
             echo "When forking this repository to make your own builds, you have to adjust this check."
             echo "When doing so make sure to randomize the scheduled cron time above, in order to spread out the various build times as much as possible."
             echo "This has been put in place due to the enormous amounts of traffic hundreds/thousands of parallel builds can cause on external infrastructure."
@@ -114,15 +114,40 @@ jobs:
           owner_type: user
           untagged_only: false
           keep_latest: 20
+  extract_macos_sdk:
+    needs: build_base
+    runs-on: "macos-12"
+    name: Extract macOS SDK
+    steps:
+      - name: "Load cache"
+        uses: actions/cache@v4
+        id: "macos_sdk_cache"
+        with:
+          path: ~/MacOSX12.3.sdk.tar.xz
+          key: MacOS-sdk
+          save-always: true
+        continue-on-error: true
+
+      - name: "Checkout osxcross"
+        if: steps.macos_sdk_cache.outputs.cache-hit != 'true'
+        uses: actions/checkout@v3
+        with:
+          repository: tpoechtrager/osxcross
+
+      - name: "Extract SDK"
+        if: steps.macos_sdk_cache.outputs.cache-hit != 'true'
+        run: |
+          XCODEDIR=/Applications/Xcode_14.0.1.app ./tools/gen_sdk_package.sh
+          mv MacOSX12.3.sdk.tar.xz ~
   build_target_bases:
     name: Build target base image
     if: ${{ github.event.inputs.buildOnly != 'true' }}
-    needs: build_base
+    needs: extract_macos_sdk
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
       matrix:
-        target: [win64,linux64,linuxarm64]
+        target: [win64,linux64,linuxarm64,macos64]
     steps:
       - name: Checkout
         uses: actions/checkout@v3
@@ -145,6 +170,18 @@ jobs:
           echo "gh_repo=${GITHUB_REPOSITORY,,}" >> $GITHUB_OUTPUT
       - name: Stop Commands
         run: T="$(echo -n ${{ github.token }} | sha256sum | head -c 64)" && echo -e "::add-mask::${T}\n::stop-commands::${T}"
+      - name: "Retrieve macOS SDK"
+        if: ${{ matrix.target == 'macos64' }}
+        uses: actions/cache@v4
+        id: "cache-sdk"
+        with:
+          path: ~/MacOSX12.3.sdk.tar.xz
+          key: MacOS-sdk
+        continue-on-error: false
+      - name: "Setup macOS SDK"
+        if: ${{ matrix.target == 'macos64' }}
+        run: |
+          cp ~/MacOSX12.3.sdk.tar.xz images/base-macos64/MacOSX12.3.sdk.tar.xz
       - name: Build target base image
         uses: docker/build-push-action@v3
         with:
@@ -175,11 +212,23 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        target: [win64,linux64]
+        target: [win64,linux64,macos64]
         variant: [lgpl-godot]
     steps:
       - name: Checkout
         uses: actions/checkout@v3
+      - name: "Retrieve macOS SDK"
+        if: ${{ matrix.target == 'macos64' }}
+        uses: actions/cache@v4
+        id: "cache-sdk"
+        with:
+          path: ~/MacOSX12.3.sdk.tar.xz
+          key: MacOS-sdk
+        continue-on-error: false
+      - name: "Setup macOS SDK"
+        if: ${{ matrix.target == 'macos64' }}
+        run: |
+          ln -s ~/MacOSX12.3.sdk.tar.xz images/base-macos64/MacOSX12.3.sdk.tar.xz
       - name: Install buildx
         uses: docker/setup-buildx-action@v2
         with:
@@ -228,11 +277,23 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        target: [win64,linux64]
+        target: [win64,linux64,macos64]
         variant: [lgpl-godot]
     steps:
       - name: Checkout
         uses: actions/checkout@v3
+      - name: "Retrieve macOS SDK"
+        if: ${{ matrix.target == 'macos64' }}
+        uses: actions/cache@v4
+        id: "cache-sdk"
+        with:
+          path: ~/MacOSX12.3.sdk.tar.xz
+          key: MacOS-sdk
+        continue-on-error: false
+      - name: "Setup macOS SDK"
+        if: ${{ matrix.target == 'macos64' }}
+        run: |
+          ln -s ~/MacOSX12.3.sdk.tar.xz images/base-macos64/MacOSX12.3.sdk.tar.xz
       - name: Login to Docker
         uses: docker/login-action@v2
         with:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -30,7 +30,7 @@ jobs:
     steps:
       - name: Repo Check
         run: |
-          if [[ "$GITHUB_REPOSITORY" != "retrohub-org/FFmpeg-Builds" ]]; then
+          if [[ "$GITHUB_REPOSITORY" != "EIRTeam/FFmpeg-Builds" ]]; then
             echo "When forking this repository to make your own builds, you have to adjust this check."
             echo "When doing so make sure to randomize the scheduled cron time above, in order to spread out the various build times as much as possible."
             echo "This has been put in place due to the enormous amounts of traffic hundreds/thousands of parallel builds can cause on external infrastructure."
@@ -147,7 +147,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        target: [win64,linux64,linuxarm64,macos64]
+        target: [win64,linux64,linuxarm64,macos64,macosarm64]
     steps:
       - name: Checkout
         uses: actions/checkout@v3
@@ -171,7 +171,7 @@ jobs:
       - name: Stop Commands
         run: T="$(echo -n ${{ github.token }} | sha256sum | head -c 64)" && echo -e "::add-mask::${T}\n::stop-commands::${T}"
       - name: "Retrieve macOS SDK"
-        if: ${{ matrix.target == 'macos64' }}
+        if: ${{ matrix.target == 'macos64' || matrix.target == 'macosarm64' }}
         uses: actions/cache@v4
         id: "cache-sdk"
         with:
@@ -179,9 +179,10 @@ jobs:
           key: MacOS-sdk
         continue-on-error: false
       - name: "Setup macOS SDK"
-        if: ${{ matrix.target == 'macos64' }}
+        if: ${{ matrix.target == 'macos64' || matrix.target == 'macosarm64' }}
         run: |
           cp ~/MacOSX12.3.sdk.tar.xz images/base-macos64/MacOSX12.3.sdk.tar.xz
+          cp ~/MacOSX12.3.sdk.tar.xz images/base-macosarm64/MacOSX12.3.sdk.tar.xz
       - name: Build target base image
         uses: docker/build-push-action@v3
         with:
@@ -212,13 +213,13 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        target: [win64,linux64,macos64]
+        target: [win64,linux64,macos64,macosarm64]
         variant: [lgpl-godot]
     steps:
       - name: Checkout
         uses: actions/checkout@v3
       - name: "Retrieve macOS SDK"
-        if: ${{ matrix.target == 'macos64' }}
+        if: ${{ matrix.target == 'macos64' || matrix.target == 'macosarm64' }}
         uses: actions/cache@v4
         id: "cache-sdk"
         with:
@@ -226,9 +227,10 @@ jobs:
           key: MacOS-sdk
         continue-on-error: false
       - name: "Setup macOS SDK"
-        if: ${{ matrix.target == 'macos64' }}
+        if: ${{ matrix.target == 'macos64' || matrix.target == 'macosarm64' }}
         run: |
-          ln -s ~/MacOSX12.3.sdk.tar.xz images/base-macos64/MacOSX12.3.sdk.tar.xz
+          cp ~/MacOSX12.3.sdk.tar.xz images/base-macos64/MacOSX12.3.sdk.tar.xz
+          cp ~/MacOSX12.3.sdk.tar.xz images/base-macosarm64/MacOSX12.3.sdk.tar.xz
       - name: Install buildx
         uses: docker/setup-buildx-action@v2
         with:
@@ -277,13 +279,13 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        target: [win64,linux64,macos64]
+        target: [win64,linux64,macos64,macosarm64]
         variant: [lgpl-godot]
     steps:
       - name: Checkout
         uses: actions/checkout@v3
       - name: "Retrieve macOS SDK"
-        if: ${{ matrix.target == 'macos64' }}
+        if: ${{ matrix.target == 'macos64' || matrix.target == 'macosarm64' }}
         uses: actions/cache@v4
         id: "cache-sdk"
         with:
@@ -291,9 +293,10 @@ jobs:
           key: MacOS-sdk
         continue-on-error: false
       - name: "Setup macOS SDK"
-        if: ${{ matrix.target == 'macos64' }}
+        if: ${{ matrix.target == 'macos64' || matrix.target == 'macosarm64' }}
         run: |
-          ln -s ~/MacOSX12.3.sdk.tar.xz images/base-macos64/MacOSX12.3.sdk.tar.xz
+          cp ~/MacOSX12.3.sdk.tar.xz images/base-macos64/MacOSX12.3.sdk.tar.xz
+          cp ~/MacOSX12.3.sdk.tar.xz images/base-macosarm64/MacOSX12.3.sdk.tar.xz
       - name: Login to Docker
         uses: docker/login-action@v2
         with:

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,5 @@
 /ffbuild/
 /artifacts/
 /.cache/
+
+MacOS*sdk.tar.xz

--- a/50-vulkan/50-shaderc.sh
+++ b/50-vulkan/50-shaderc.sh
@@ -28,8 +28,15 @@ ffbuild_dockerbuild() {
     # for some reason, this does not get installed...
     cp libshaderc_util/libshaderc_util.a "$FFBUILD_PREFIX"/lib
 
-    echo "Libs: -lstdc++" >> "$FFBUILD_PREFIX"/lib/pkgconfig/shaderc_combined.pc
-    echo "Libs: -lstdc++" >> "$FFBUILD_PREFIX"/lib/pkgconfig/shaderc_static.pc
+    unset CPP_LIB
+    if [[ $TARGET == macos* ]]; then
+        CPP_LIB="c++"
+    else
+        CPP_LIB="stdc++"
+    fi
+
+    echo "Libs: -l$CPP_LIB" >> "$FFBUILD_PREFIX"/lib/pkgconfig/shaderc_combined.pc
+    echo "Libs: -l$CPP_LIB" >> "$FFBUILD_PREFIX"/lib/pkgconfig/shaderc_static.pc
 
     cp "$FFBUILD_PREFIX"/lib/pkgconfig/{shaderc_combined,shaderc}.pc
 

--- a/50-vulkan/55-spirv-cross.sh
+++ b/50-vulkan/55-spirv-cross.sh
@@ -23,6 +23,13 @@ ffbuild_dockerbuild() {
     make -j$(nproc)
     make install
 
+    unset CPP_LIB
+    if [[ $TARGET == macos* ]]; then
+        CPP_LIB="c++"
+    else
+        CPP_LIB="stdc++"
+    fi
+
     cat >"$FFBUILD_PREFIX"/lib/pkgconfig/spirv-cross-c-shared.pc <<EOF
 prefix=$FFBUILD_PREFIX
 exec_prefix=\${prefix}
@@ -35,7 +42,7 @@ Description: C API for SPIRV-Cross
 Version: $VER_FULL
 
 Requires:
-Libs: -L\${libdir} -L\${sharedlibdir} -lspirv-cross-c -lspirv-cross-glsl -lspirv-cross-hlsl -lspirv-cross-reflect -lspirv-cross-msl -lspirv-cross-util -lspirv-cross-core -lstdc++
+Libs: -L\${libdir} -L\${sharedlibdir} -lspirv-cross-c -lspirv-cross-glsl -lspirv-cross-hlsl -lspirv-cross-reflect -lspirv-cross-msl -lspirv-cross-util -lspirv-cross-core -l\${CPP_LIB}
 Cflags: -I\${includedir}
 EOF
 }

--- a/50-vulkan/60-libplacebo.sh
+++ b/50-vulkan/60-libplacebo.sh
@@ -42,7 +42,7 @@ ffbuild_dockerbuild() {
         )
     fi
 
-    if [[ $TARGET == win* || $TARGET == linux* ]]; then
+    if [[ $TARGET == win* || $TARGET == linux* || $TARGET == macos* ]]; then
         myconf+=(
             --cross-file=/cross.meson
         )
@@ -55,7 +55,14 @@ ffbuild_dockerbuild() {
     ninja -j$(nproc)
     ninja install
 
-    echo "Libs.private: -lstdc++" >> "$FFBUILD_PREFIX"/lib/pkgconfig/libplacebo.pc
+    unset CPP_LIB
+    if [[ $TARGET == macos* ]]; then
+        CPP_LIB="c++"
+    else
+        CPP_LIB="stdc++"
+    fi
+
+    echo "Libs.private: -l$CPP_LIB" >> "$FFBUILD_PREFIX"/lib/pkgconfig/libplacebo.pc
 }
 
 ffbuild_configure() {

--- a/README.md
+++ b/README.md
@@ -1,8 +1,10 @@
 # FFmpeg Static Auto-Builds
 
-Static Windows (x86_64) and Linux (x86_64) Builds of ffmpeg master and latest release branch.
+Static Windows (x86_64), macOS (x86_64) and Linux (x86_64) Builds of ffmpeg master and latest release branch.
 
 Windows builds are targetting Windows 7 and newer.
+
+macOS builds are targetting macOS 12.3 and newer (Monterey - darwin21.4)
 
 Linux (x86_64) builds are targetting Ubuntu 16.04 (glibc-2.23 + linux-4.4) and anything more recent.
 
@@ -47,6 +49,7 @@ On success, the resulting zip file will be in the `artifacts` subdir.
 Available targets:
 * `win64` (x86_64 Windows)
 * `win32` (x86 Windows)
+* `macos64` (x86_64 macOS)
 * `linux64` (x86_64 Linux, glibc>=2.23, linux>=4.4)
 * `linuxarm64` (arm64 (aarch64) Linux, glibc>=2.27, linux>=4.15)
 

--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
 # FFmpeg Static Auto-Builds
 
-Static Windows (x86_64), macOS (x86_64) and Linux (x86_64) Builds of ffmpeg master and latest release branch.
+Static Windows (x86_64), macOS (x86_64 and arm64) and Linux (x86_64) Builds of ffmpeg master and latest release branch.
 
 Windows builds are targetting Windows 7 and newer.
 
-macOS builds are targetting macOS 12.3 and newer (Monterey - darwin21.4)
+macOS (x86_64 and arm64) builds are targetting macOS 12.3 and newer (Monterey - darwin21.4)
 
 Linux (x86_64) builds are targetting Ubuntu 16.04 (glibc-2.23 + linux-4.4) and anything more recent.
 
@@ -34,6 +34,13 @@ Every file corresponds to its respective package.
 * bash
 * docker
 
+> [!WARNING]
+> To compile for macOS, you'll need to provide the SDK (`MacOSX12.3.sdk.tar.xz`) yourself. This can be extracted from a macOS machine or from downloading Xcode by [follow these instructions](https://github.com/tpoechtrager/osxcross?tab=readme-ov-file#packaging-the-sdk).
+>
+> Once extracted, place the SDK in the following directories, depending on your target:
+> - **x86_64** - `images/base-macos64`
+> - **arm64** - `images/base-macosarm64`
+
 ### Build Image
 
 * `./makeimage.sh target variant [addin [addin] [addin] ...]`
@@ -50,6 +57,7 @@ Available targets:
 * `win64` (x86_64 Windows)
 * `win32` (x86 Windows)
 * `macos64` (x86_64 macOS)
+* `macosarm64` (arm64 macOS)
 * `linux64` (x86_64 Linux, glibc>=2.23, linux>=4.4)
 * `linuxarm64` (arm64 (aarch64) Linux, glibc>=2.27, linux>=4.15)
 

--- a/build.sh
+++ b/build.sh
@@ -33,6 +33,11 @@ for script in scripts.d/**/*.sh; do
     FF_LIBS+=" $(get_output $script libs)"
 done
 
+if [[ $TARGET == macos* ]]; then
+    FF_CFLAGS+=" -mmacosx-version-min=12.3"
+    FF_CXXFLAGS+=" -mmacosx-version-min=12.3"
+fi
+
 FF_CONFIGURE="$(xargs <<< "$FF_CONFIGURE")"
 FF_CFLAGS="$(xargs <<< "$FF_CFLAGS")"
 FF_CXXFLAGS="$(xargs <<< "$FF_CXXFLAGS")"

--- a/images/base-macos64/Dockerfile
+++ b/images/base-macos64/Dockerfile
@@ -1,0 +1,39 @@
+ARG GH_REPO=ghcr.io/btbn/ffmpeg-builds
+FROM $GH_REPO/base:latest
+
+RUN --mount=src=MacOSX12.3.sdk.tar.xz,dst=/sdk.tar.xz \
+    git clone https://github.com/tpoechtrager/osxcross.git /opt/osxcross && \
+    cd /opt/osxcross && \
+    git fetch --all && \
+    git checkout ff8d100f3f026b4ffbe4ce96d8aac4ce06f1278b && \
+    ln -s /sdk.tar.xz /opt/osxcross/tarballs/MacOSX12.3.sdk.tar.xz && \
+    UNATTENDED=1 ./build.sh
+
+RUN rustup target add x86_64-apple-darwin
+
+ADD toolchain.cmake /toolchain.cmake
+ADD cross.meson /cross.meson
+
+ENV FFBUILD_TOOLCHAIN=x86_64-apple-darwin21.4
+ENV PATH="/opt/osxcross/target/bin:${PATH}" \
+    FFBUILD_TARGET_FLAGS="--pkg-config=pkg-config --cross-prefix=${FFBUILD_TOOLCHAIN}- --arch=x86_64 --target-os=darwin" \
+    FFBUILD_CROSS_PREFIX="${FFBUILD_TOOLCHAIN}-" \
+    FFBUILD_RUST_TARGET="x86_64-apple-darwin" \
+    FFBUILD_PREFIX=/opt/ffbuild \
+    FFBUILD_CMAKE_TOOLCHAIN=/toolchain.cmake \
+    PKG_CONFIG=pkg-config \
+    PKG_CONFIG_LIBDIR=/opt/ffbuild/lib/pkgconfig:/opt/ffbuild/share/pkgconfig \
+    CC="${FFBUILD_TOOLCHAIN}-clang" \
+    CXX="${FFBUILD_TOOLCHAIN}-clang++" \
+    LD="${FFBUILD_TOOLCHAIN}-ld" \
+    AR="${FFBUILD_TOOLCHAIN}-ar" \
+    RANLIB="${FFBUILD_TOOLCHAIN}-ranlib" \
+    NM="${FFBUILD_TOOLCHAIN}-nm" \
+## zlib produces test files with off64_t variables. There is no support for _LARGE_FILE64_SOURCE / _FILE_OFFSET_BITS
+## flags in Clang yet: https://github.com/llvm/llvm-project/issues/77376
+## So, for now we redefine this type to int64_t
+    CFLAGS="-mmacosx-version-min=12.3 -Doff64_t=int64_t -I/opt/ffbuild/include -O2 -pipe -fPIC -DPIC -pthread" \
+    CXXFLAGS="-mmacosx-version-min=12.3 -I/opt/ffbuild/include -O2 -pipe -fPIC -DPIC -pthread" \
+    LDFLAGS="-L/opt/ffbuild/lib -O2 -pipe -pthread -lm" \
+    STAGE_CFLAGS="-fvisibility=hidden" \
+    STAGE_CXXFLAGS="-fvisibility=hidden"

--- a/images/base-macos64/cross.meson
+++ b/images/base-macos64/cross.meson
@@ -1,0 +1,13 @@
+[binaries]
+c = 'x86_64-apple-darwin21.4-clang'
+cpp = 'x86_64-apple-darwin21.4-clang++'
+ld = 'x86_64-apple-darwin21.4-ld'
+ar = 'x86_64-apple-darwin21.4-ar'
+ranlib = 'x86_64-apple-darwin21.4-ranlib'
+strip = 'x86_64-apple-darwin21.4-strip'
+
+[host_machine]
+system = 'darwin'
+cpu_family = 'x86_64'
+cpu = 'x86_64'
+endian = 'little'

--- a/images/base-macos64/toolchain.cmake
+++ b/images/base-macos64/toolchain.cmake
@@ -1,0 +1,11 @@
+set(CMAKE_SYSTEM_NAME Darwin)
+set(CMAKE_SYSTEM_PROCESSOR x86_64)
+
+set(triple x86_64-apple-darwin21.4)
+
+set(CMAKE_C_COMPILER ${triple}-clang)
+set(CMAKE_CXX_COMPILER ${triple}-clang++)
+set(CMAKE_RANLIB ${triple}-ranlib)
+set(CMAKE_AR ${triple}-ar)
+
+set(CMAKE_OSX_DEPLOYMENT_TARGET 12.3)

--- a/images/base-macosarm64/Dockerfile
+++ b/images/base-macosarm64/Dockerfile
@@ -1,0 +1,39 @@
+ARG GH_REPO=ghcr.io/btbn/ffmpeg-builds
+FROM $GH_REPO/base:latest
+
+RUN --mount=src=MacOSX12.3.sdk.tar.xz,dst=/sdk.tar.xz \
+    git clone https://github.com/tpoechtrager/osxcross.git /opt/osxcross && \
+    cd /opt/osxcross && \
+    git fetch --all && \
+    git checkout ff8d100f3f026b4ffbe4ce96d8aac4ce06f1278b && \
+    ln -s /sdk.tar.xz /opt/osxcross/tarballs/MacOSX12.3.sdk.tar.xz && \
+    UNATTENDED=1 ./build.sh
+
+RUN rustup target add aarch64-apple-darwin
+
+ADD toolchain.cmake /toolchain.cmake
+ADD cross.meson /cross.meson
+
+ENV FFBUILD_TOOLCHAIN=aarch64-apple-darwin21.4
+ENV PATH="/opt/osxcross/target/bin:${PATH}" \
+    FFBUILD_TARGET_FLAGS="--pkg-config=pkg-config --cross-prefix=${FFBUILD_TOOLCHAIN}- --arch=aarch64 --target-os=darwin" \
+    FFBUILD_CROSS_PREFIX="${FFBUILD_TOOLCHAIN}-" \
+    FFBUILD_RUST_TARGET="aarch64-apple-darwin" \
+    FFBUILD_PREFIX=/opt/ffbuild \
+    FFBUILD_CMAKE_TOOLCHAIN=/toolchain.cmake \
+    PKG_CONFIG=pkg-config \
+    PKG_CONFIG_LIBDIR=/opt/ffbuild/lib/pkgconfig:/opt/ffbuild/share/pkgconfig \
+    CC="${FFBUILD_TOOLCHAIN}-clang" \
+    CXX="${FFBUILD_TOOLCHAIN}-clang++" \
+    LD="${FFBUILD_TOOLCHAIN}-ld" \
+    AR="${FFBUILD_TOOLCHAIN}-ar" \
+    RANLIB="${FFBUILD_TOOLCHAIN}-ranlib" \
+    NM="${FFBUILD_TOOLCHAIN}-nm" \
+## zlib produces test files with off64_t variables. There is no support for _LARGE_FILE64_SOURCE / _FILE_OFFSET_BITS
+## flags in Clang yet: https://github.com/llvm/llvm-project/issues/77376
+## So, for now we redefine this type to int64_t
+    CFLAGS="-mmacosx-version-min=12.3 -Doff64_t=int64_t -I/opt/ffbuild/include -O2 -pipe -fPIC -DPIC -pthread" \
+    CXXFLAGS="-mmacosx-version-min=12.3 -I/opt/ffbuild/include -O2 -pipe -fPIC -DPIC -pthread" \
+    LDFLAGS="-L/opt/ffbuild/lib -O2 -pipe -pthread -lm" \
+    STAGE_CFLAGS="-fvisibility=hidden" \
+    STAGE_CXXFLAGS="-fvisibility=hidden"

--- a/images/base-macosarm64/cross.meson
+++ b/images/base-macosarm64/cross.meson
@@ -1,0 +1,13 @@
+[binaries]
+c = 'aarch64-apple-darwin21.4-clang'
+cpp = 'aarch64-apple-darwin21.4-clang++'
+ld = 'aarch64-apple-darwin21.4-ld'
+ar = 'aarch64-apple-darwin21.4-ar'
+ranlib = 'aarch64-apple-darwin21.4-ranlib'
+strip = 'aarch64-apple-darwin21.4-strip'
+
+[host_machine]
+system = 'darwin'
+cpu_family = 'aarch64'
+cpu = 'aarch64'
+endian = 'little'

--- a/images/base-macosarm64/toolchain.cmake
+++ b/images/base-macosarm64/toolchain.cmake
@@ -1,0 +1,11 @@
+set(CMAKE_SYSTEM_NAME Darwin)
+set(CMAKE_SYSTEM_PROCESSOR aarch64)
+
+set(triple aarch64-apple-darwin21.4)
+
+set(CMAKE_C_COMPILER ${triple}-clang)
+set(CMAKE_CXX_COMPILER ${triple}-clang++)
+set(CMAKE_RANLIB ${triple}-ranlib)
+set(CMAKE_AR ${triple}-ar)
+
+set(CMAKE_OSX_DEPLOYMENT_TARGET 12.3)

--- a/images/base/Dockerfile
+++ b/images/base/Dockerfile
@@ -14,7 +14,8 @@ RUN \
         gperf itstool ragel libc6-dev libssl-dev \
         gtk-doc-tools gobject-introspection gawk \
         ocaml ocamlbuild libnum-ocaml-dev indent p7zip-full \
-        python3-distutils python3-jinja2 python3-jsonschema python3-apt python-is-python3 && \
+        python3-distutils python3-jinja2 python3-jsonschema python3-apt python-is-python3 \
+        zlib1g-dev && \
     apt-get -y clean && \
     git config --global user.email "builder@localhost" && \
     git config --global user.name "Builder" && \

--- a/scripts.d/20-libiconv.sh
+++ b/scripts.d/20-libiconv.sh
@@ -3,7 +3,10 @@
 SCRIPT_REPO="https://git.savannah.gnu.org/git/libiconv.git"
 SCRIPT_COMMIT="6e2b31f6d66739c5abd850338ea68c6bd2012812"
 
+# macOS has iconv in the system, but this one is GNU's iconv. This creates name clash between iconv and libiconv, and
+# linker fails to find the correct one. More info at https://stackoverflow.com/questions/57734434/libiconv-or-iconv-undefined-symbol-on-mac-osx
 ffbuild_enabled() {
+    if [[ $TARGET == macos* ]]; then return -1; fi
     return 0
 }
 
@@ -25,7 +28,7 @@ ffbuild_dockerbuild() {
         --with-pic
     )
 
-    if [[ $TARGET == win* || $TARGET == linux* ]]; then
+    if [[ $TARGET == win* || $TARGET == linux* || $TARGET == macos* ]]; then
         myconf+=(
             --host="$FFBUILD_TOOLCHAIN"
         )

--- a/scripts.d/20-libxml2.sh
+++ b/scripts.d/20-libxml2.sh
@@ -18,7 +18,7 @@ ffbuild_dockerbuild() {
         --enable-static
     )
 
-    if [[ $TARGET == win* || $TARGET == linux* ]]; then
+    if [[ $TARGET == win* || $TARGET == linux* || $TARGET == macos* ]]; then
         myconf+=(
             --host="$FFBUILD_TOOLCHAIN"
         )

--- a/scripts.d/20-zlib.sh
+++ b/scripts.d/20-zlib.sh
@@ -15,9 +15,11 @@ ffbuild_dockerbuild() {
         --static
     )
 
+    export AR="${FFBUILD_CROSS_PREFIX}ar"
     if [[ $TARGET == win* || $TARGET == linux* ]]; then
         export CC="${FFBUILD_CROSS_PREFIX}gcc"
-        export AR="${FFBUILD_CROSS_PREFIX}ar"
+    elif [[ $TARGET == macos* ]]; then
+        export CC="${FFBUILD_CROSS_PREFIX}clang"
     else
         echo "Unknown target"
         return -1

--- a/scripts.d/25-fftw3.sh
+++ b/scripts.d/25-fftw3.sh
@@ -31,7 +31,7 @@ ffbuild_dockerbuild() {
         )
     fi
 
-    if [[ $TARGET == win* || $TARGET == linux* ]]; then
+    if [[ $TARGET == win* || $TARGET == linux* || $TARGET == macos* ]]; then
         myconf+=(
             --host="$FFBUILD_TOOLCHAIN"
         )

--- a/scripts.d/25-fribidi.sh
+++ b/scripts.d/25-fribidi.sh
@@ -21,7 +21,7 @@ ffbuild_dockerbuild() {
         -Dtests=false
     )
 
-    if [[ $TARGET == win* || $TARGET == linux* ]]; then
+    if [[ $TARGET == win* || $TARGET == linux* || $TARGET == macos* ]]; then
         myconf+=(
             --cross-file=/cross.meson
         )

--- a/scripts.d/25-gmp.sh
+++ b/scripts.d/25-gmp.sh
@@ -20,7 +20,7 @@ ffbuild_dockerbuild() {
         --with-pic
     )
 
-    if [[ $TARGET == win* || $TARGET == linux* ]]; then
+    if [[ $TARGET == win* || $TARGET == linux* || $TARGET == macos* ]]; then
         myconf+=(
             --host="$FFBUILD_TOOLCHAIN"
         )

--- a/scripts.d/25-libogg.sh
+++ b/scripts.d/25-libogg.sh
@@ -19,7 +19,7 @@ ffbuild_dockerbuild() {
         --with-pic
     )
 
-    if [[ $TARGET == win* || $TARGET == linux* ]]; then
+    if [[ $TARGET == win* || $TARGET == linux* || $TARGET == macos* ]]; then
         myconf+=(
             --host="$FFBUILD_TOOLCHAIN"
         )

--- a/scripts.d/25-openssl.sh
+++ b/scripts.d/25-openssl.sh
@@ -47,6 +47,11 @@ ffbuild_dockerbuild() {
             --cross-compile-prefix="$FFBUILD_CROSS_PREFIX"
             linux-aarch64
         )
+    elif [[ $TARGET == macos64 ]]; then
+        myconf+=(
+            --cross-compile-prefix="$FFBUILD_CROSS_PREFIX"
+            darwin64-x86_64-cc
+        )
     else
         echo "Unknown target"
         return -1

--- a/scripts.d/25-openssl.sh
+++ b/scripts.d/25-openssl.sh
@@ -52,6 +52,11 @@ ffbuild_dockerbuild() {
             --cross-compile-prefix="$FFBUILD_CROSS_PREFIX"
             darwin64-x86_64-cc
         )
+    elif [[ $TARGET == macosarm64 ]]; then
+        myconf+=(
+            --cross-compile-prefix="$FFBUILD_CROSS_PREFIX"
+            darwin64-arm64-cc
+        )
     else
         echo "Unknown target"
         return -1

--- a/scripts.d/25-xz.sh
+++ b/scripts.d/25-xz.sh
@@ -20,7 +20,7 @@ ffbuild_dockerbuild() {
         --with-pic
     )
 
-    if [[ $TARGET == win* || $TARGET == linux* ]]; then
+    if [[ $TARGET == win* || $TARGET == linux* || $TARGET == macos* ]]; then
         myconf+=(
             --host="$FFBUILD_TOOLCHAIN"
         )

--- a/scripts.d/45-harfbuzz.sh
+++ b/scripts.d/45-harfbuzz.sh
@@ -17,7 +17,7 @@ ffbuild_dockerbuild() {
         --with-pic
     )
 
-    if [[ $TARGET == win* || $TARGET == linux* ]]; then
+    if [[ $TARGET == win* || $TARGET == linux* || $TARGET == macos* ]]; then
         myconf+=(
             --host="$FFBUILD_TOOLCHAIN"
         )

--- a/scripts.d/45-libudfread.sh
+++ b/scripts.d/45-libudfread.sh
@@ -19,7 +19,7 @@ ffbuild_dockerbuild() {
         --with-pic
     )
 
-    if [[ $TARGET == win* || $TARGET == linux* ]]; then
+    if [[ $TARGET == win* || $TARGET == linux* || $TARGET == macos* ]]; then
         myconf+=(
             --host="$FFBUILD_TOOLCHAIN"
         )

--- a/scripts.d/45-libvorbis.sh
+++ b/scripts.d/45-libvorbis.sh
@@ -19,7 +19,7 @@ ffbuild_dockerbuild() {
         --disable-oggtest
     )
 
-    if [[ $TARGET == win* || $TARGET == linux* ]]; then
+    if [[ $TARGET == win* || $TARGET == linux* || $TARGET == macos* ]]; then
         myconf+=(
             --host="$FFBUILD_TOOLCHAIN"
         )

--- a/scripts.d/45-vmaf.sh
+++ b/scripts.d/45-vmaf.sh
@@ -26,7 +26,7 @@ ffbuild_dockerbuild() {
         -Denable_float=true
     )
 
-    if [[ $TARGET == win* || $TARGET == linux* ]]; then
+    if [[ $TARGET == win* || $TARGET == linux* || $TARGET == macos* ]]; then
         myconf+=(
             --cross-file=/cross.meson
         )
@@ -39,7 +39,14 @@ ffbuild_dockerbuild() {
     ninja -j"$(nproc)"
     ninja install
 
-    sed -i 's/Libs.private:/Libs.private: -lstdc++/; t; $ a Libs.private: -lstdc++' "$FFBUILD_PREFIX"/lib/pkgconfig/libvmaf.pc
+    unset CPP_LIB
+    if [[ $TARGET == macos* ]]; then
+        CPP_LIB="c++"
+    else
+        CPP_LIB="stdc++"
+    fi
+
+    sed -i "s/Libs.private:/Libs.private: -l$CPP_LIB/; t; \$ a Libs.private: -l$CPP_LIB" "$FFBUILD_PREFIX"/lib/pkgconfig/libvmaf.pc
 }
 
 ffbuild_configure() {

--- a/scripts.d/50-dav1d.sh
+++ b/scripts.d/50-dav1d.sh
@@ -18,7 +18,7 @@ ffbuild_dockerbuild() {
         --default-library=static
     )
 
-    if [[ $TARGET == win* || $TARGET == linux* ]]; then
+    if [[ $TARGET == win* || $TARGET == linux* || $TARGET == macos* ]]; then
         myconf+=(
             --cross-file=/cross.meson
         )

--- a/scripts.d/50-fdk-aac.sh
+++ b/scripts.d/50-fdk-aac.sh
@@ -21,7 +21,7 @@ ffbuild_dockerbuild() {
         --disable-example
     )
 
-    if [[ $TARGET == win* || $TARGET == linux* ]]; then
+    if [[ $TARGET == win* || $TARGET == linux* || $TARGET == macos* ]]; then
         myconf+=(
             --host="$FFBUILD_TOOLCHAIN"
         )

--- a/scripts.d/50-ffnvcodec.sh
+++ b/scripts.d/50-ffnvcodec.sh
@@ -1,13 +1,15 @@
 #!/bin/bash
 
 SCRIPT_REPO="https://github.com/FFmpeg/nv-codec-headers.git"
-SCRIPT_COMMIT="855f8263d97bbdcaeabaaaa2997e1ccad7c52dc3"
+SCRIPT_COMMIT="75f032b24263c2b684b9921755cafc1c08e41b9d"
 
 SCRIPT_REPO2="https://github.com/FFmpeg/nv-codec-headers.git"
 SCRIPT_COMMIT2="dc3e4484dc83485734e503991fe5ed3bdf256fba"
 SCRIPT_BRANCH2="sdk/11.1"
 
 ffbuild_enabled() {
+    # No NVENC on macOS
+    if [[ $TARGET == macos* ]]; then return -1; fi
     return 0
 }
 

--- a/scripts.d/50-libmp3lame.sh
+++ b/scripts.d/50-libmp3lame.sh
@@ -27,7 +27,7 @@ ffbuild_dockerbuild() {
         --disable-decoder
     )
 
-    if [[ $TARGET == win* || $TARGET == linux* ]]; then
+    if [[ $TARGET == win* || $TARGET == linux* || $TARGET == macos* ]]; then
         myconf+=(
             --host="$FFBUILD_TOOLCHAIN"
         )

--- a/scripts.d/50-libopus.sh
+++ b/scripts.d/50-libopus.sh
@@ -19,7 +19,7 @@ ffbuild_dockerbuild() {
         --disable-extra-programs
     )
 
-    if [[ $TARGET == win* || $TARGET == linux* ]]; then
+    if [[ $TARGET == win* || $TARGET == linux* || $TARGET == macos* ]]; then
         myconf+=(
             --host="$FFBUILD_TOOLCHAIN"
         )

--- a/scripts.d/50-libtheora.sh
+++ b/scripts.d/50-libtheora.sh
@@ -24,7 +24,7 @@ ffbuild_dockerbuild() {
         --disable-doc
     )
 
-    if [[ $TARGET == win* || $TARGET == linux* ]]; then
+    if [[ $TARGET == win* || $TARGET == linux* || $TARGET == macos* ]]; then
         myconf+=(
             --host="$FFBUILD_TOOLCHAIN"
         )

--- a/scripts.d/50-libvpx.sh
+++ b/scripts.d/50-libvpx.sh
@@ -47,6 +47,11 @@ ffbuild_dockerbuild() {
             --target=x86_64-darwin21-gcc
         )
         export CROSS="$FFBUILD_CROSS_PREFIX"
+    elif [[ $TARGET == macosarm64 ]]; then
+        myconf+=(
+            --target=arm64-darwin21-gcc
+        )
+        export CROSS="$FFBUILD_CROSS_PREFIX"
     else
         echo "Unknown target"
         return -1

--- a/scripts.d/50-libvpx.sh
+++ b/scripts.d/50-libvpx.sh
@@ -42,6 +42,11 @@ ffbuild_dockerbuild() {
             --target=arm64-linux-gcc
         )
         export CROSS="$FFBUILD_CROSS_PREFIX"
+    elif [[ $TARGET == macos64 ]]; then
+        myconf+=(
+            --target=x86_64-darwin21-gcc
+        )
+        export CROSS="$FFBUILD_CROSS_PREFIX"
     else
         echo "Unknown target"
         return -1

--- a/scripts.d/50-openh264.sh
+++ b/scripts.d/50-openh264.sh
@@ -57,6 +57,12 @@ ffbuild_dockerbuild() {
             ARCH=x86_64
             STATIC_LDFLAGS=-lc++
         )
+    elif [[ $TARGET == macosarm64 ]]; then
+        myconf+=(
+            OS=darwin
+            ARCH=arm64
+            STATIC_LDFLAGS=-lc++
+        )
     else
         echo "Unknown target"
         return -1

--- a/scripts.d/50-openh264.sh
+++ b/scripts.d/50-openh264.sh
@@ -16,10 +16,20 @@ ffbuild_dockerbuild() {
         BUILDTYPE=Release
         DEBUGSYMBOLS=False
         LIBDIR_NAME=lib
-        CC="$FFBUILD_CROSS_PREFIX"gcc
-        CXX="$FFBUILD_CROSS_PREFIX"g++
         AR="$FFBUILD_CROSS_PREFIX"ar
     )
+
+    if [[ $TARGET == macos* ]]; then
+        myconf+=(
+            CC="$FFBUILD_CROSS_PREFIX"clang
+            CXX="$FFBUILD_CROSS_PREFIX"clang++
+        )
+    else
+        myconf+=(
+            CC="$FFBUILD_CROSS_PREFIX"gcc
+            CXX="$FFBUILD_CROSS_PREFIX"g++
+        )
+    fi
 
     if [[ $TARGET == win32 ]]; then
         myconf+=(
@@ -40,6 +50,12 @@ ffbuild_dockerbuild() {
         myconf+=(
             OS=linux
             ARCH=aarch64
+        )
+    elif [[ $TARGET == macos64 ]]; then
+        myconf+=(
+            OS=darwin
+            ARCH=x86_64
+            STATIC_LDFLAGS=-lc++
         )
     else
         echo "Unknown target"

--- a/scripts.d/50-soxr.sh
+++ b/scripts.d/50-soxr.sh
@@ -12,11 +12,18 @@ ffbuild_dockerbuild() {
 
     mkdir build && cd build
 
-    cmake -DCMAKE_TOOLCHAIN_FILE="$FFBUILD_CMAKE_TOOLCHAIN" -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX="$FFBUILD_PREFIX" -DWITH_OPENMP=ON -DBUILD_TESTS=OFF -DBUILD_EXAMPLES=OFF -DBUILD_SHARED_LIBS=OFF ..
+    # Disable OpenMP on macOS
+    unset FFBUILD_OPENMP
+    if [[ $TARGET != macos* ]]; then
+        FFBUILD_OPENMP="-DWITH_OPENMP=ON"
+    fi
+    cmake -DCMAKE_TOOLCHAIN_FILE="$FFBUILD_CMAKE_TOOLCHAIN" -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX="$FFBUILD_PREFIX" "$FFBUILD_OPENMP" -DBUILD_TESTS=OFF -DBUILD_EXAMPLES=OFF -DBUILD_SHARED_LIBS=OFF ..
     make -j$(nproc)
     make install
 
-    echo "Libs.private: -lgomp" >> "$FFBUILD_PREFIX"/lib/pkgconfig/soxr.pc
+    if [[ $TARGET != macos* ]]; then
+        echo "Libs.private: -lgomp" >> "$FFBUILD_PREFIX"/lib/pkgconfig/soxr.pc
+    fi
 }
 
 ffbuild_configure() {
@@ -32,5 +39,7 @@ ffbuild_ldflags() {
 }
 
 ffbuild_libs() {
-    echo -lgomp
+    if [[ $TARGET != macos* ]]; then
+        echo -lgomp
+    fi
 }

--- a/scripts.d/50-svtav1.sh
+++ b/scripts.d/50-svtav1.sh
@@ -1,7 +1,8 @@
 #!/bin/bash
 
 SCRIPT_REPO="https://gitlab.com/AOMediaCodec/SVT-AV1.git"
-SCRIPT_COMMIT="08c18ba0768ed3dbbff0903adc326fb3a7549bd9"
+# Required update due to https://gitlab.com/AOMediaCodec/SVT-AV1/-/issues/2128
+SCRIPT_COMMIT="59645eea34e2815b627b8293aa3af254eddd0d69"
 
 ffbuild_enabled() {
     [[ $TARGET == win32 ]] && return -1

--- a/scripts.d/50-twolame.sh
+++ b/scripts.d/50-twolame.sh
@@ -21,7 +21,7 @@ ffbuild_dockerbuild() {
         --disable-sndfile
     )
 
-    if [[ $TARGET == win* || $TARGET == linux* ]]; then
+    if [[ $TARGET == win* || $TARGET == linux* || $TARGET == macos* ]]; then
         myconf+=(
             --host="$FFBUILD_TOOLCHAIN"
         )

--- a/scripts.d/50-zimg.sh
+++ b/scripts.d/50-zimg.sh
@@ -24,10 +24,15 @@ ffbuild_dockerbuild() {
         --with-pic
     )
 
-    if [[ $TARGET == win* || $TARGET == linux* ]]; then
+    if [[ $TARGET == win* || $TARGET == linux* || $TARGET == macos* ]]; then
         myconf+=(
             --host="$FFBUILD_TOOLCHAIN"
         )
+        if [[ $TARGET == macos* ]]; then
+            myconf+=(
+                STL_LIBS="-lc++"
+            )
+        fi
     else
         echo "Unknown target"
         return -1

--- a/scripts.d/99-rpath.sh
+++ b/scripts.d/99-rpath.sh
@@ -3,7 +3,7 @@
 SCRIPT_SKIP="1"
 
 ffbuild_enabled() {
-    [[ $TARGET == linux* ]]
+    [[ $TARGET == linux* ]] || [[ $TARGET == macos* ]]
 }
 
 ffbuild_dockerfinal() {
@@ -35,7 +35,12 @@ ffbuild_ldexeflags() {
 
     if [[ $VARIANT == *shared* ]]; then
         # Can't escape escape hell
-        echo -Wl,-rpath='\\\\\\\$\\\$ORIGIN'
-        echo -Wl,-rpath='\\\\\\\$\\\$ORIGIN/../lib'
+        if [[ $TARGET == macos* ]]; then
+            echo -Wl,-rpath,'\\\\\\\$\\\$ORIGIN'
+            echo -Wl,-rpath,'\\\\\\\$\\\$ORIGIN/../lib'
+        else
+            echo -Wl,-rpath='\\\\\\\$\\\$ORIGIN'
+            echo -Wl,-rpath='\\\\\\\$\\\$ORIGIN/../lib'
+        fi
     fi
 }

--- a/variants/macos-install-shared-godot.sh
+++ b/variants/macos-install-shared-godot.sh
@@ -1,0 +1,26 @@
+#!/bin/bash
+
+package_variant() {
+    IN="$1"
+    OUT="$2"
+
+    mkdir -p "$OUT"/lib
+    cp -a "$IN"/lib/*.dylib* "$OUT"/lib
+
+    mkdir -p "$OUT"/lib/pkgconfig
+    cp -a "$IN"/lib/pkgconfig/*.pc "$OUT"/lib/pkgconfig
+    sed -i \
+        -e 's|^prefix=.*|prefix=${pcfiledir}/../..|' \
+        -e 's|/ffbuild/prefix|${prefix}|' \
+        -e '/Libs.private:/d' \
+        "$OUT"/lib/pkgconfig/*.pc
+
+    mkdir -p "$OUT"/include
+    cp -r "$IN"/include/* "$OUT"/include
+
+    mkdir -p "$OUT"/doc
+    cp -r "$IN"/share/doc/ffmpeg/* "$OUT"/doc
+
+    mkdir -p "$OUT/man"
+    cp -r "$IN"/share/man/* "$OUT"/man
+}

--- a/variants/macos64-lgpl-godot.sh
+++ b/variants/macos64-lgpl-godot.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+source "$(dirname "$BASH_SOURCE")"/macos-install-shared-godot.sh
+source "$(dirname "$BASH_SOURCE")"/defaults-lgpl-shared.sh
+source "$(dirname "$BASH_SOURCE")"/lgpl-godot.sh
+
+FFBUILD_TOOLCHAIN=x86_64-apple-darwin21.4
+
+FF_CONFIGURE+=" --cc=${FFBUILD_TOOLCHAIN}-clang --cxx=${FFBUILD_TOOLCHAIN}-clang++ --install-name-dir=@loader_path"
+
+TOOLBOX="--enable-videotoolbox"
+
+FF_CONFIGURE+=" $TOOLBOX"

--- a/variants/macosarm64-lgpl-godot.sh
+++ b/variants/macosarm64-lgpl-godot.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+source "$(dirname "$BASH_SOURCE")"/macos-install-shared-godot.sh
+source "$(dirname "$BASH_SOURCE")"/defaults-lgpl-shared.sh
+source "$(dirname "$BASH_SOURCE")"/lgpl-godot.sh
+
+FFBUILD_TOOLCHAIN=arm64-apple-darwin21.4
+
+FF_CONFIGURE+=" --cc=${FFBUILD_TOOLCHAIN}-clang --cxx=${FFBUILD_TOOLCHAIN}-clang++ --install-name-dir=@loader_path"
+
+TOOLBOX="--enable-videotoolbox"
+NEON="--enable-neon"
+
+FF_CONFIGURE+=" $TOOLBOX $NEON"


### PR DESCRIPTION
This adds new Docker files for cross-compiling to macOS (both x86_64 and arm64) through [osxcross](https://github.com/tpoechtrager/osxcross), as well as modifying plenty of scripts to support it.

Cross-compilation requires the macOS SDK to be present on `images/base-macos64 | images/base-macosarm64`, which cannot be publicly distributed. The CI has an intermediate step for extracting the SDK to bypass this. For the end user, an additional note was added on the README.md on how to obtain this SDK.

The **x86_64** build was tested on a macOS Monterey machine, and seems to be working without issue.

> [!WARNING]
> The **arm64** build is completely untested as I don't have a M1 machine, thus for any issues that arise in this version, my support will be very limited.